### PR TITLE
fix: correct language display in Beehive Dashboards (Norwegian support)

### DIFF
--- a/public/text/dashboard/en.json
+++ b/public/text/dashboard/en.json
@@ -1,0 +1,5 @@
+{
+    "dashboardToday": "Dashboard Today",
+    "dashboardAllTime": "Dashboard All Time",
+    "currentlyListening": "Currently Listening"
+}

--- a/public/text/dashboard/no.json
+++ b/public/text/dashboard/no.json
@@ -1,0 +1,5 @@
+{
+    "dashboardToday": "Dashboard I dag",
+    "dashboardAllTime": "Dashboard Alle tider",
+    "currentlyListening": "Lytter akkurat nå"
+}

--- a/src/components/music/dashboards.tsx
+++ b/src/components/music/dashboards.tsx
@@ -1,9 +1,27 @@
 'use client'
 
+import {useState, useEffect} from 'react'
 import { setCookie } from '@utils/cookies'
 import Link from 'next/link'
+import dashboard_no from '@text/dashboard/no.json'
+import dashboard_en from '@text/dashboard/en.json'
+import { getCookie } from '@utils/cookies'
+import { language } from '@components/shared/langtoggle/LangToggle'
 
 export default function Dashboards() {
+    const [lang, setLang] = useState('no')
+    const [text, setText] = useState(dashboard_no)
+
+    useEffect(() => {
+        const dashboardText = lang === 'no' ? dashboard_no : dashboard_en
+        setText(dashboardText)
+    }, [lang])
+
+    useEffect(() => {
+        const temp = getCookie('lang')
+        setLang(temp || 'no')
+    }, [language])
+
     const style = 'flex items-center gap-4 p-4 rounded-lg bg-[var(--color-bg-surface)] shadow-none w-full font-semibold'
 
     function handleClick() {
@@ -12,9 +30,9 @@ export default function Dashboards() {
 
     return (
         <div className='flex flex-col md:flex-row gap-4'>
-            <Link href='/music/dashboard/today' onClick={handleClick} className={style}>Dashboard Today</Link>
-            <Link href='/music/dashboard/all' onClick={handleClick} className={style}>Dashboard All Time</Link>
-            <Link href='/music/dashboard/current' onClick={handleClick} className={style}>Currently Listening</Link>
+            <Link href='/music/dashboard/today' onClick={handleClick} className={style}>{text.dashboardToday}</Link>
+            <Link href='/music/dashboard/all' onClick={handleClick} className={style}>{text.dashboardAllTime}</Link>
+            <Link href='/music/dashboard/current' onClick={handleClick} className={style}>{text.currentlyListening}</Link>
         </div>
     )
 }


### PR DESCRIPTION
## Description

Fixed issue where Beehive Dashboards always display text in the selected language in the Music Dashboard.

## Related Issues

- Closes #33 

## Changes Made

- Fixed language handling logic for Beehive Dashboards  
- Verified correct display of Norwegian text in Music Dashboard  
- Ensured language preference is respected across reloads  

## How to Test

1. Pull this branch  
2. Run `npm install`  
3. Start services: `docker-compose --profile dev up`  
4. Go to [http://localhost:3000/music](http://localhost:3000/music)  
5. Switch language to **Norwegian**  
6. Verify that dashboard text is now displayed in Norwegian  

## Screenshots (if applicable)

<!-- Add screenshots of English vs Norwegian dashboards -->

## Checklist

- [x] Bug resolved and tested locally  
- [x] Code follows project conventions  
- [x] Verified Norwegian text renders correctly in dashboard  
